### PR TITLE
HTU21DF Driver. 

### DIFF
--- a/Raspberry.IO.GeneralPurpose/GpioConnectionDriver.cs
+++ b/Raspberry.IO.GeneralPurpose/GpioConnectionDriver.cs
@@ -291,13 +291,11 @@ namespace Raspberry.IO.GeneralPurpose
         {
             switch (processor)
             {
-                case Processor.Bcm2708:
+                case Processor.Bcm2835:
                     return Interop.BCM2835_GPIO_BASE;
 
-                case Processor.Bcm2709:
-                    return Interop.BCM2836_GPIO_BASE;
-                
-                case Processor.BCM2835: // <- added this one JJ FIX per RB3
+                case Processor.Bcm2836:
+                case Processor.Bcm2837:
                     return Interop.BCM2836_GPIO_BASE;
 
                 default:

--- a/Raspberry.IO.GeneralPurpose/MemoryGpioConnectionDriver.cs
+++ b/Raspberry.IO.GeneralPurpose/MemoryGpioConnectionDriver.cs
@@ -247,10 +247,11 @@ namespace Raspberry.IO.GeneralPurpose
         {
             switch (processor)
             {
-                case Processor.Bcm2708:
+                case Processor.Bcm2835:
                     return Interop.BCM2835_GPIO_BASE;
 
-                case Processor.Bcm2709:
+                case Processor.Bcm2836:
+                case Processor.Bcm2837:
                     return Interop.BCM2836_GPIO_BASE;
 
                 default:

--- a/Raspberry.IO.InterIntegratedCircuit/I2cDriver.cs
+++ b/Raspberry.IO.InterIntegratedCircuit/I2cDriver.cs
@@ -478,7 +478,8 @@ namespace Raspberry.IO.InterIntegratedCircuit
                 if ((SafeReadUInt32(status) & Interop.BCM2835_BSC_S_CLKT) != 0) // Received Clock Stretch Timeout
                     throw new InvalidOperationException("Read operation failed with BCM2835_I2C_REASON_ERROR_CLKT status");
                 if (remaining != 0) // Not all data is received
-                    throw new InvalidOperationException(string.Format("Read operation failed with BCM2835_I2C_REASON_ERROR_DATA status, missing {0} bytes", remaining));
+                    throw new InvalidOperationException(
+                        $"Read operation failed with BCM2835_I2C_REASON_ERROR_DATA status, missing {remaining} bytes" );
 
                 WriteUInt32Mask(control, Interop.BCM2835_BSC_S_DONE, Interop.BCM2835_BSC_S_DONE);
 
@@ -490,11 +491,11 @@ namespace Raspberry.IO.InterIntegratedCircuit
         {
             switch (processor)
             {
-                case Processor.Bcm2708:
-                case Processor.BCM2835: // <- added this one JJ FIX per RB3
+                case Processor.Bcm2835:
                     return Interop.BCM2835_BSC1_BASE;
 
-                case Processor.Bcm2709:
+                case Processor.Bcm2836:
+                case Processor.Bcm2837:
                     return Interop.BCM2836_BSC1_BASE;
                 
                 default:
@@ -506,11 +507,11 @@ namespace Raspberry.IO.InterIntegratedCircuit
         {
             switch (processor)
             {
-                case Processor.Bcm2708:
-                case Processor.BCM2835: // <- added this one JJ FIX per RB3
+                case Processor.Bcm2835:
                     return Interop.BCM2835_GPIO_BASE;
 
-                case Processor.Bcm2709:
+                case Processor.Bcm2836:
+                case Processor.Bcm2837:
                     return Interop.BCM2836_GPIO_BASE;
 
                 default:

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyCompany("Raspberry#")]
 [assembly: AssemblyProduct("Raspberry.IO")]
-[assembly: AssemblyCopyright("www.raspberry-sharp.org, 2012-2015")]
+[assembly: AssemblyCopyright("www.raspberry-sharp.org, 2012-2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.1.1.0")]
-[assembly: AssemblyFileVersion("3.1.1.0")]
+[assembly: AssemblyVersion("3.1.2.0")]
+[assembly: AssemblyFileVersion("3.1.2.0")]


### PR DESCRIPTION
Works with updated Raspberry.System assembly (V3.1.2) with support for new revision code. I2C comms have been tested with:

Pi Zero W - BCM2835
Pi2 Model B - BCM2836
Pi3 Model B - BCM2837